### PR TITLE
Modification of the manifest

### DIFF
--- a/Chromium/manifest.json
+++ b/Chromium/manifest.json
@@ -19,7 +19,8 @@
         "default_title": "Click to open panel"
     },
     "host_permissions": [ 
-        "https://checkmyhttps.net/*"
+        "https://checkmyhttps.net/*",
+        "https://*/*"
     ],
     "permissions": ["storage", "sidePanel", "tabs", "notifications"]
 }


### PR DESCRIPTION
Adding a new line to host_permission in the manifest, so that the extension can automatically retrieve the public key from the verification server.