### PR TITLE
Apply POST method for fetching data

### DIFF
--- a/Chromium/lib/api.js
+++ b/Chromium/lib/api.js
@@ -14,7 +14,13 @@ CMH.api = {}
 CMH.api.requestFromUrl = async (urlTested) => {
  const { host, port } = CMH.common.parseURL(urlTested)
 
- const { data:response_data, response } = await CMH.certificatesManager.getCertUrl(CMH.options.settings.checkServerUrl+'api.php?host='+encodeURIComponent(host)+'&port='+port)
+ let arguments = {
+    host: encodeURIComponent(host),
+    port: port,
+    sign: true
+ }
+
+ const { data:response_data, response } = await CMH.certificatesManager.getCertUrl(CMH.options.settings.checkServerUrl+"api.php", false, arguments);
  if ( response === null ) {
    return { error: 'SERVER_UNREACHABLE' }
  }

--- a/Chromium/lib/certificatesManager.js
+++ b/Chromium/lib/certificatesManager.js
@@ -13,7 +13,7 @@ CMH.certificatesManager = {}
  * @param {boolean} [httpHeadMethod=false] - Use HTTP HEAD method
  * Get the certificate of an URL.
  */
-CMH.certificatesManager.getCertUrl = async (urlTested, httpHeadMethod=false) => {
+CMH.certificatesManager.getCertUrl = async (urlTested, httpHeadMethod=false, arguments={}) => {
   let response      = null
   let response_data = null
 
@@ -21,7 +21,7 @@ CMH.certificatesManager.getCertUrl = async (urlTested, httpHeadMethod=false) => 
     if (httpHeadMethod) {
       fetchInit = { method: 'HEAD' }
     } else {
-      fetchInit = {}
+      fetchInit = { method: 'POST', headers: {"Content-Type": "application/json"}, cache: 'no-cache', body: JSON.stringify(arguments)}
     }
     response = await fetch(urlTested, fetchInit)
 


### PR DESCRIPTION
We have changed the method used for the fetch api call. Previously we used the get method and now we use the post method.